### PR TITLE
회원가입 페이지 퍼블리싱 및 select 컴포넌트 

### DIFF
--- a/src/components/common/button.tsx
+++ b/src/components/common/button.tsx
@@ -12,14 +12,14 @@ export default function Button({
   return disabled ? (
     <button
       {...rest}
-      className="w-full transition cursor-not-allowed opacity-30 h-[40px] text-headline rounded-lg border border-transparen hover:bg-sc-org-2 bg-sc-org-1 px-4 font-extralight text-white"
+      className="w-full transition cursor-not-allowed opacity-30 h-[40px] text-headline rounded-lg border border-transparen hover:bg-sc-org-2 bg-sc-org-1 px-4 text-white"
     >
       {text}
     </button>
   ) : (
     <button
       {...rest}
-      className="w-full transition hover:cursor-pointer h-[40px] text-headline rounded-lg border border-transparen hover:bg-sc-org-2 bg-sc-org-1 px-4 font-extralight text-white"
+      className="w-full transition hover:cursor-pointer h-[40px] text-headline rounded-lg border border-transparen hover:bg-sc-org-2 bg-sc-org-1 px-4 text-white"
     >
       {text}
     </button>

--- a/src/components/common/button.tsx
+++ b/src/components/common/button.tsx
@@ -12,14 +12,14 @@ export default function Button({
   return disabled ? (
     <button
       {...rest}
-      className="w-full cursor-not-allowed opacity-30 h-[40px] text-headline rounded-lg border border-transparen hover:bg-sc-org-2 bg-sc-org-1 px-4 font-extralight text-white"
+      className="w-full transition cursor-not-allowed opacity-30 h-[40px] text-headline rounded-lg border border-transparen hover:bg-sc-org-2 bg-sc-org-1 px-4 font-extralight text-white"
     >
       {text}
     </button>
   ) : (
     <button
       {...rest}
-      className="w-full hover:cursor-pointer h-[40px] text-headline rounded-lg border border-transparen hover:bg-sc-org-2 bg-sc-org-1 px-4 font-extralight text-white"
+      className="w-full transition hover:cursor-pointer h-[40px] text-headline rounded-lg border border-transparen hover:bg-sc-org-2 bg-sc-org-1 px-4 font-extralight text-white"
     >
       {text}
     </button>

--- a/src/components/common/input.tsx
+++ b/src/components/common/input.tsx
@@ -12,11 +12,12 @@ interface InputProps {
 }
 
 export default function Input({
+  register,
   isLabel = false,
   labelText,
   name,
   size = 'default',
-  type,
+  type = 'text',
   placeholder,
   ...rest
 }: InputProps) {
@@ -33,29 +34,32 @@ export default function Input({
 
       {size === 'default' && (
         <input
+          {...register}
           {...rest}
           placeholder={placeholder}
           name={name}
           type={type}
-          className="w-full border-none appearance-none focus:outline-none focus:ring-sc-org-1 focus:border-sc-org-1  placeholder:text-sc-grays-2 text-sc-black bg-sc-grays-6 rounded-[4px] px-2.5 h-[32px] text-footNote font-normal transition"
+          className="w-full border-none appearance-none focus:outline-none focus:ring-sc-org-1 focus:border-sc-org-1  placeholder:text-sc-grays-2 text-sc-black bg-sc-grays-6 rounded px-2.5 h-8 text-footNote font-normal transition"
         ></input>
       )}
       {size === 'small' && (
         <input
+          {...register}
           {...rest}
           placeholder={placeholder}
           name={name}
           type={type}
-          className="w-full border-none appearance-none focus:outline-none focus:ring-sc-org-1 focus:border-sc-org-1  placeholder:text-sc-grays-2 text-sc-black  bg-sc-grays-6 rounded-[4px] px-2.5 h-[28px] text-footNote font-normal transition"
+          className="w-full border-none appearance-none focus:outline-none focus:ring-sc-org-1 focus:border-sc-org-1  placeholder:text-sc-grays-2 text-sc-black  bg-sc-grays-6 rounded px-2.5 h-7 text-footNote font-normal transition"
         ></input>
       )}
       {size === 'large' && (
         <input
+          {...register}
           {...rest}
           placeholder={placeholder}
           name={name}
           type={type}
-          className="w-full border-none appearance-none focus:outline-none focus:ring-sc-org-1 focus:border-sc-org-1  placeholder:text-sc-grays-2 text-sc-black bg-sc-grays-6 rounded-[4px] px-2.5 h-[36px] text-footNote font-normal transition"
+          className="w-full border-none appearance-none focus:outline-none focus:ring-sc-org-1 focus:border-sc-org-1  placeholder:text-sc-grays-2 text-sc-black bg-sc-grays-6 rounded px-2.5 h-9 text-footNote font-normal transition"
         ></input>
       )}
     </div>

--- a/src/components/common/input.tsx
+++ b/src/components/common/input.tsx
@@ -12,10 +12,10 @@ interface InputProps {
 }
 
 export default function Input({
+  name,
   register,
   isLabel = false,
   labelText,
-  name,
   size = 'default',
   type = 'text',
   placeholder,
@@ -37,7 +37,7 @@ export default function Input({
           {...register}
           {...rest}
           placeholder={placeholder}
-          name={name}
+          id={name}
           type={type}
           className="w-full border-none appearance-none focus:outline-none focus:ring-sc-org-1 focus:border-sc-org-1  placeholder:text-sc-grays-2 text-sc-black bg-sc-grays-6 rounded px-2.5 h-8 text-footNote font-normal transition"
         ></input>
@@ -47,7 +47,7 @@ export default function Input({
           {...register}
           {...rest}
           placeholder={placeholder}
-          name={name}
+          id={name}
           type={type}
           className="w-full border-none appearance-none focus:outline-none focus:ring-sc-org-1 focus:border-sc-org-1  placeholder:text-sc-grays-2 text-sc-black  bg-sc-grays-6 rounded px-2.5 h-7 text-footNote font-normal transition"
         ></input>
@@ -57,7 +57,7 @@ export default function Input({
           {...register}
           {...rest}
           placeholder={placeholder}
-          name={name}
+          id={name}
           type={type}
           className="w-full border-none appearance-none focus:outline-none focus:ring-sc-org-1 focus:border-sc-org-1  placeholder:text-sc-grays-2 text-sc-black bg-sc-grays-6 rounded px-2.5 h-9 text-footNote font-normal transition"
         ></input>

--- a/src/components/common/select.tsx
+++ b/src/components/common/select.tsx
@@ -1,5 +1,5 @@
 import cls from '@utils/cls';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import type {
   FieldPath,
   UseFormRegisterReturn,
@@ -29,8 +29,7 @@ export default function Select<T extends FieldValues>({
   options,
   ...rest
 }: SelectProps<T>) {
-  const [focus, setFocus] = useState<boolean>(false);
-  const optionRef = useRef<HTMLDivElement>(null);
+  const [isActive, setIsActive] = useState<boolean>(false);
 
   return (
     <div>
@@ -45,7 +44,7 @@ export default function Select<T extends FieldValues>({
       <input
         {...register}
         {...rest}
-        onFocus={() => setFocus(true)}
+        onFocus={() => setIsActive(true)}
         // onBlur={() => setFocus(false)}
         placeholder={placeholder}
         id={name}
@@ -53,10 +52,9 @@ export default function Select<T extends FieldValues>({
         className="w-full border-none appearance-none  focus:outline-none focus:ring-sc-org-1 focus:border-sc-org-1  placeholder:text-sc-grays-2 text-sc-black bg-sc-grays-6 rounded-[4px] px-2.5 py-0 h-8 text-footNote font-normal transition"
       />
       <div
-        ref={optionRef}
         className={cls(
           'mt-2 divide-y-[1px] w-full rounded-lg shadow-md transition overflow-hidden',
-          focus ? 'block' : 'hidden',
+          isActive ? 'block' : 'hidden',
         )}
       >
         {[...options].reverse().map((option, index) => (
@@ -64,7 +62,7 @@ export default function Select<T extends FieldValues>({
             className="transition flex w-full items-center h-11 px-4 text-footNote text-sc-grays-1 hover:bg-sc-org-1 hover:text-sc-white"
             key={index}
             onClick={() => {
-              setFocus(false);
+              setIsActive(false);
               setValue(name, option as FieldPathValue<T, FieldPath<T>>);
             }}
           >

--- a/src/components/common/select.tsx
+++ b/src/components/common/select.tsx
@@ -1,0 +1,77 @@
+import cls from '@utils/cls';
+import { useRef, useState } from 'react';
+import type {
+  FieldPath,
+  UseFormRegisterReturn,
+  UseFormSetValue,
+  FieldPathValue,
+  FieldValues,
+} from 'react-hook-form';
+
+interface SelectProps<T extends FieldValues> {
+  name: FieldPath<T>;
+  setValue: UseFormSetValue<T>;
+  register?: UseFormRegisterReturn;
+  placeholder: string;
+  isLabel?: boolean;
+  labelText?: string;
+  options: string[];
+  [key: string]: any;
+}
+
+export default function Select<T extends FieldValues>({
+  register,
+  setValue,
+  isLabel = false,
+  labelText,
+  name,
+  placeholder,
+  options,
+  ...rest
+}: SelectProps<T>) {
+  const [focus, setFocus] = useState<boolean>(false);
+  const optionRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div>
+      {isLabel && (
+        <label
+          className="mb-[6px] block text-caption1 font-m text-sc-grays-1"
+          htmlFor={name}
+        >
+          {labelText}
+        </label>
+      )}
+      <input
+        {...register}
+        {...rest}
+        onFocus={() => setFocus(true)}
+        // onBlur={() => setFocus(false)}
+        placeholder={placeholder}
+        id={name}
+        type="text"
+        className="w-full border-none appearance-none  focus:outline-none focus:ring-sc-org-1 focus:border-sc-org-1  placeholder:text-sc-grays-2 text-sc-black bg-sc-grays-6 rounded-[4px] px-2.5 py-0 h-8 text-footNote font-normal transition"
+      />
+      <div
+        ref={optionRef}
+        className={cls(
+          'mt-2 divide-y-[1px] w-full rounded-lg shadow-md transition overflow-hidden',
+          focus ? 'block' : 'hidden',
+        )}
+      >
+        {[...options].reverse().map((option, index) => (
+          <div
+            className="transition flex w-full items-center h-11 px-4 text-footNote text-sc-grays-1 hover:bg-sc-org-1 hover:text-sc-white"
+            key={index}
+            onClick={() => {
+              setFocus(false);
+              setValue(name, option as FieldPathValue<T, FieldPath<T>>);
+            }}
+          >
+            {option}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/signup/signup01.tsx
+++ b/src/pages/signup/signup01.tsx
@@ -35,7 +35,7 @@ export default function Signup() {
         <br /> 동의해주세요.
       </h1>
       <form autoComplete="off" className="space-y-4">
-        <div className="mt-[32px]">
+        <div className="mt-8">
           <Checkbox
             id="selectAll"
             text="모두동의 (선택사항 포함)"
@@ -43,10 +43,10 @@ export default function Signup() {
             handler={(e) => onCheckedAll(e.target.checked)}
           />
         </div>
-        <div className="mx-[8px]">
+        <div className="mx-2">
           <div className="w-full h-[1px] bg-sc-grays-6 my-[20px]"></div>
           <ul className="mb-64">
-            <li className="mb-[8px]">
+            <li className="mb-2">
               <Checkbox
                 id="term1"
                 text="만 14세 이상"
@@ -54,25 +54,25 @@ export default function Signup() {
                 handler={(e) => onChecked(e.target.checked, e.target.id)}
               />
             </li>
-            <li className="mb-[8px] flex relative">
+            <li className="mb-2 flex relative">
               <Checkbox
                 id="term2"
                 text="이용약관 동의"
                 isChecked={checkedTerm.includes('term2') ? true : false}
                 handler={(e) => onChecked(e.target.checked, e.target.id)}
               />
-              <button className="absolute bottom-[1px] right-[154px] ml-[8px] text-caption1 font-extralight underline decoration-sc-grays-1">
+              <button className="absolute bottom-[1px] right-[154px] ml-2 text-caption1 font-extralight underline decoration-sc-grays-1">
                 보기
               </button>
             </li>
-            <li className="mb-[8px] flex relative">
+            <li className="mb-2 flex relative">
               <Checkbox
                 id="term3"
                 text="개인정보 처리방침 동의"
                 isChecked={checkedTerm.includes('term3') ? true : false}
                 handler={(e) => onChecked(e.target.checked, e.target.id)}
               />
-              <button className="absolute bottom-[1px] right-[104px] ml-[8px] text-caption1 font-extralight underline decoration-sc-grays-1">
+              <button className="absolute bottom-[1px] right-[104px] ml-2 text-caption1 font-extralight underline decoration-sc-grays-1">
                 보기
               </button>
             </li>

--- a/src/pages/signup/signup02.tsx
+++ b/src/pages/signup/signup02.tsx
@@ -2,21 +2,53 @@ import Button from '@components/common/button';
 import Layout from '@components/common/layout';
 import ProgressBar from '@components/common/progressBar';
 import Input from '@components/common/input';
+import { useForm } from 'react-hook-form';
+import Select from '@components/common/select';
+
+export interface SignupForm {
+  university: string;
+  admission_year: number;
+}
 
 export default function Signup() {
+  const { register, handleSubmit, setValue } = useForm<SignupForm>();
+
+  const onValid = (form: SignupForm) => {
+    console.log(form);
+  };
+
   return (
     <Layout>
       <ProgressBar totalPage={5} currentPage={2} />
       <h1 className="text-title3 font-medium">
         인증 받으실 학교와 학번을 <br /> 선택해주세요.????
       </h1>
-      <form autoComplete="off" className="mt-10">
+      <form onSubmit={handleSubmit(onValid)} className="mt-10">
         <div className="grid grid-cols-1 gap-4">
           <Input
             name="university"
+            type="text"
             placeholder="재학 중인 학교를 검색해주세요."
+            register={register('university')}
           />
-          <Input name="admission_year" placeholder="입학년도를 선택해주세요." />
+          <Select
+            name="admission_year"
+            placeholder="입학년도를 선택해주세요."
+            register={register('admission_year')}
+            setValue={setValue}
+            isLabel
+            labelText="입학년도"
+            options={[
+              '2015',
+              '2016',
+              '2017',
+              '2018',
+              '2019',
+              '2020',
+              '2021',
+              '2022',
+            ]}
+          />
         </div>
         <div className="mt-8">
           <Button text="다음" />

--- a/src/pages/signup/signup02.tsx
+++ b/src/pages/signup/signup02.tsx
@@ -1,0 +1,27 @@
+import Button from '@components/common/button';
+import Layout from '@components/common/layout';
+import ProgressBar from '@components/common/progressBar';
+import Input from '@components/common/input';
+
+export default function Signup() {
+  return (
+    <Layout>
+      <ProgressBar totalPage={5} currentPage={2} />
+      <h1 className="text-title3 font-medium">
+        인증 받으실 학교와 학번을 <br /> 선택해주세요.????
+      </h1>
+      <form autoComplete="off" className="mt-10">
+        <div className="grid grid-cols-1 gap-4">
+          <Input
+            name="university"
+            placeholder="재학 중인 학교를 검색해주세요."
+          />
+          <Input name="admission_year" placeholder="입학년도를 선택해주세요." />
+        </div>
+        <div className="mt-8">
+          <Button text="다음" />
+        </div>
+      </form>
+    </Layout>
+  );
+}

--- a/src/pages/signup/signup02.tsx
+++ b/src/pages/signup/signup02.tsx
@@ -36,8 +36,6 @@ export default function Signup() {
             placeholder="입학년도를 선택해주세요."
             register={register('admission_year')}
             setValue={setValue}
-            isLabel
-            labelText="입학년도"
             options={[
               '2015',
               '2016',

--- a/src/pages/signup/signup03.tsx
+++ b/src/pages/signup/signup03.tsx
@@ -1,0 +1,55 @@
+import Button from '@components/common/button';
+import Layout from '@components/common/layout';
+import ProgressBar from '@components/common/progressBar';
+import Input from '@components/common/input';
+
+export default function Signup() {
+  return (
+    <Layout>
+      <ProgressBar totalPage={5} currentPage={3} />
+      <h1 className="text-title3 font-medium">
+        아이디로 사용될 이메일을 <br />
+        입력 후 인증해주세요.
+      </h1>
+      <form autoComplete="off" className="mt-10">
+        <div className="grid grid-cols-1 gap-4">
+          <Input name="university" placeholder="아이디 (이메일) 입력" />
+          <Input
+            name="university"
+            placeholder="입력하신 메일로 전송된 번호를 입력해주세요."
+          />
+        </div>
+        <div className="text-sc-err text-caption2 flex items-center mt-[6px]">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 10.75C12.4142 10.75 12.75 11.0858 12.75 11.5V16.5C12.75 16.9142 12.4142 17.25 12 17.25C11.5858 17.25 11.25 16.9142 11.25 16.5V11.5C11.25 11.0858 11.5858 10.75 12 10.75Z"
+              fill="#BA1E45"
+            />
+            <path
+              d="M12 9C12.5523 9 13 8.55228 13 8C13 7.44772 12.5523 7 12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9Z"
+              fill="#BA1E45"
+            />
+            <path
+              fill-rule="evenodd"
+              clip-rule="evenodd"
+              d="M3.25 12C3.25 7.16751 7.16751 3.25 12 3.25C16.8325 3.25 20.75 7.16751 20.75 12C20.75 16.8325 16.8325 20.75 12 20.75C7.16751 20.75 3.25 16.8325 3.25 12ZM12 4.75C7.99594 4.75 4.75 7.99594 4.75 12C4.75 16.0041 7.99594 19.25 12 19.25C16.0041 19.25 19.25 16.0041 19.25 12C19.25 7.99594 16.0041 4.75 12 4.75Z"
+              fill="#BA1E45"
+            />
+          </svg>
+          <span className="pl-[2px]">전송 된 번호는 10분간 유효합니다.</span>
+        </div>
+
+        <div className="mt-8">
+          <Button text="다음" />
+          <Button text="인증번호 전송" />
+        </div>
+      </form>
+    </Layout>
+  );
+}

--- a/src/pages/signup/signup03.tsx
+++ b/src/pages/signup/signup03.tsx
@@ -13,9 +13,9 @@ export default function Signup() {
       </h1>
       <form autoComplete="off" className="mt-10">
         <div className="grid grid-cols-1 gap-4">
-          <Input name="university" placeholder="아이디 (이메일) 입력" />
+          <Input name="email" placeholder="아이디 (이메일) 입력" />
           <Input
-            name="university"
+            name="confirm"
             placeholder="입력하신 메일로 전송된 번호를 입력해주세요."
           />
         </div>

--- a/src/pages/signup/signup04.tsx
+++ b/src/pages/signup/signup04.tsx
@@ -1,0 +1,73 @@
+import Button from '@components/common/button';
+import Layout from '@components/common/layout';
+import ProgressBar from '@components/common/progressBar';
+import Input from '@components/common/input';
+
+export default function Signup() {
+  return (
+    <Layout>
+      <ProgressBar totalPage={5} currentPage={4} />
+      <h1 className="text-title3 font-medium">
+        회원정보를 <br />
+        입력해주세요.
+      </h1>
+      <form autoComplete="off" className="mt-10 ">
+        <div className="grid grid-cols-1 gap-5">
+          <Input
+            name="nickname"
+            isLabel
+            labelText="닉네임"
+            placeholder="영문, 한글, 숫자 혼합 최대 12자 가능"
+          />
+          <Input
+            name="password"
+            isLabel
+            labelText="비밀번호"
+            placeholder="영대소문자, 숫자 최소 8자 이상"
+          />
+          <Input
+            name="confirmPassword"
+            isLabel
+            labelText="비밀번호 확인"
+            placeholder="비밀번호 재입력"
+          />
+          <Input
+            name="confirmPassword"
+            isLabel
+            labelText="성별"
+            placeholder="성별 선택"
+          />
+        </div>
+        <div className="text-sc-err text-caption2 flex items-center mt-[6px]">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 10.75C12.4142 10.75 12.75 11.0858 12.75 11.5V16.5C12.75 16.9142 12.4142 17.25 12 17.25C11.5858 17.25 11.25 16.9142 11.25 16.5V11.5C11.25 11.0858 11.5858 10.75 12 10.75Z"
+              fill="#BA1E45"
+            />
+            <path
+              d="M12 9C12.5523 9 13 8.55228 13 8C13 7.44772 12.5523 7 12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9Z"
+              fill="#BA1E45"
+            />
+            <path
+              fill-rule="evenodd"
+              clip-rule="evenodd"
+              d="M3.25 12C3.25 7.16751 7.16751 3.25 12 3.25C16.8325 3.25 20.75 7.16751 20.75 12C20.75 16.8325 16.8325 20.75 12 20.75C7.16751 20.75 3.25 16.8325 3.25 12ZM12 4.75C7.99594 4.75 4.75 7.99594 4.75 12C4.75 16.0041 7.99594 19.25 12 19.25C16.0041 19.25 19.25 16.0041 19.25 12C19.25 7.99594 16.0041 4.75 12 4.75Z"
+              fill="#BA1E45"
+            />
+          </svg>
+          <span className="pl-[2px]">전송 된 번호는 10분간 유효합니다.</span>
+        </div>
+
+        <div className="mt-[130px]">
+          <Button text="슬러쉬 시작하기" />
+        </div>
+      </form>
+    </Layout>
+  );
+}

--- a/src/pages/signup/signup04.tsx
+++ b/src/pages/signup/signup04.tsx
@@ -32,7 +32,7 @@ export default function Signup() {
             placeholder="비밀번호 재입력"
           />
           <Input
-            name="confirmPassword"
+            name="gender"
             isLabel
             labelText="성별"
             placeholder="성별 선택"


### PR DESCRIPTION
- 회원가입 페이지 라우팅은 signup/signup01과 같이 합니다. 
- input 컴포넌트를 토대로 select 컴포넌트를 만들었습니다. 
- 선택할 option의 배열인 options와 react-hook-form의 register, setValue 함수를 props로 넘겨주어야 합니다. 
- typescript generic을 사용하여 select 컴포넌트의 props를 정의해주었습니다. 
- 현재 select box에 focus를 준 뒤 바깥을 클릭해도 드랍다운된 option들이 사라지지 않는 버그가 있습니다. 