### PR TITLE
redux-toolkit 스토어 연결 & 전역으로 관리할 유저 상태 세팅

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,15 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.38.0",
-    "react-query": "^3.39.2"
+    "react-query": "^3.39.2",
+    "react-redux": "^8.0.5",
+    "redux-persist": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "18.11.7",
     "@types/react": "18.0.24",
-    "@typescript-eslint/eslint-plugin": "^5.31.0",
     "@types/react-dom": "18.0.8",
+    "@typescript-eslint/eslint-plugin": "^5.31.0",
     "autoprefixer": "^10.4.12",
     "eslint": "^8.26.0",
     "eslint-config-next": "13.0.0",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,20 @@
 import type { AppProps } from 'next/app';
 import '../styles/globals.css';
+import { Provider } from 'react-redux';
+import store from '../redux/store';
+import { PersistGate } from 'redux-persist/integration/react';
+import { persistStore } from 'redux-persist';
+
+const persistor = persistStore(store);
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <div className="mx-auto w-full max-w-[375px]">
-      <Component {...pageProps} />
+      <Provider store={store}>
+        <PersistGate loading={null} persistor={persistor}>
+          <Component {...pageProps} />
+        </PersistGate>
+      </Provider>
     </div>
   );
 }

--- a/src/redux/hooks.ts
+++ b/src/redux/hooks.ts
@@ -1,0 +1,6 @@
+import { useDispatch, useSelector } from 'react-redux';
+import type { TypedUseSelectorHook } from 'react-redux';
+import type { RootState, AppDispatch } from './store';
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/redux/slices/userSlice.ts
+++ b/src/redux/slices/userSlice.ts
@@ -2,12 +2,12 @@ import { createSlice } from '@reduxjs/toolkit';
 
 interface userState {
   university: string;
-  admission_year: Date | null;
+  admission_year: string;
   email: string;
 }
 const initialState: userState = {
   university: '',
-  admission_year: null,
+  admission_year: '',
   email: '',
 };
 

--- a/src/redux/slices/userSlice.ts
+++ b/src/redux/slices/userSlice.ts
@@ -1,0 +1,27 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+interface userState {
+  university: string;
+  admission_year: Date | null;
+  email: string;
+}
+const initialState: userState = {
+  university: '',
+  admission_year: null,
+  email: '',
+};
+
+const userSlice = createSlice({
+  name: 'userReducer',
+  initialState,
+  reducers: {
+    setUserForm: (state, action) => {
+      state.university = action.payload.university;
+      state.admission_year = action.payload.admission_year;
+      state.email = action.payload.email;
+    },
+  },
+});
+
+export const { setUserForm } = userSlice.actions;
+export default userSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,0 +1,38 @@
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
+import userSlice from './slices/userSlice';
+import storage from 'redux-persist/lib/storage';
+import {
+  persistReducer,
+  FLUSH,
+  REHYDRATE,
+  PAUSE,
+  PERSIST,
+  PURGE,
+  REGISTER,
+} from 'redux-persist';
+
+const rootReducer = combineReducers({
+  user: userSlice,
+});
+
+const persistConfig = {
+  key: 'root',
+  storage,
+  whitelist: ['user'],
+};
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
+const store = configureStore({
+  reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: {
+        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+      },
+    }),
+});
+
+export default store;
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
- rtk store를 생성하여 전역으로 관리하기 위해 _app.tsx에 스토어를 연결했습니다.
- rtk store로 상태 관리할때 새로고침시 state가 초기화 되는 상황을 방지하기 위해 redux-persist를 추가했습니다.
- redux를 사용하기 위해 필요한 패키지 react-redux & react-persist 를 추가했습니다.
- TS 내에서 useSelector와 useDispatch를 사용하기 위해 필요한 타입 설정을 위한 hooks.ts 파일을 추가했습니다.
- 회원가입 마지막 페이지에서 입력하는 닉네임, 비밀번호, 성별을 제외한 학교, 입학년도, 이메일을 전역으로 관리하기 위한 userSlice를 생성했습니다.