### PR TITLE
Select 컴포넌트 

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@headlessui/react": "^1.7.4",
     "@reduxjs/toolkit": "^1.8.6",
     "@tailwindcss/forms": "^0.5.3",
     "axios": "^1.1.3",

--- a/src/components/common/select.tsx
+++ b/src/components/common/select.tsx
@@ -94,7 +94,7 @@ export default function Select<T extends FieldValues>({
               leaveTo="opacity-0"
             >
               <Listbox.Options className="shadow-lg divide-y-[1px] absolute text-footNote font-normal z-10 mt-2 w-full rounded bg-white overflow-hidden ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
-                {options?.map((option) => (
+                {[...options]?.reverse().map((option) => (
                   <Listbox.Option
                     key={option.id}
                     className={({ active }) =>

--- a/src/components/common/select.tsx
+++ b/src/components/common/select.tsx
@@ -1,5 +1,5 @@
-import cls from '@utils/cls';
-import { useState } from 'react';
+import { Fragment, useState, useEffect } from 'react';
+import { Listbox, Transition } from '@headlessui/react';
 import type {
   FieldPath,
   UseFormRegisterReturn,
@@ -7,6 +7,12 @@ import type {
   FieldPathValue,
   FieldValues,
 } from 'react-hook-form';
+import cls from '@utils/cls';
+
+type Option = {
+  id: number;
+  option: string;
+};
 
 interface SelectProps<T extends FieldValues> {
   name: FieldPath<T>;
@@ -15,12 +21,11 @@ interface SelectProps<T extends FieldValues> {
   placeholder: string;
   isLabel?: boolean;
   labelText?: string;
-  options: string[];
+  options: Option[];
   [key: string]: any;
 }
 
 export default function Select<T extends FieldValues>({
-  register,
   setValue,
   isLabel = false,
   labelText,
@@ -29,47 +34,102 @@ export default function Select<T extends FieldValues>({
   options,
   ...rest
 }: SelectProps<T>) {
-  const [isActive, setIsActive] = useState<boolean>(false);
+  const [selected, setSelected] = useState<Option>({
+    id: 0,
+    option: placeholder,
+  });
+
+  useEffect(() => {
+    if (selected.id !== 0)
+      setValue(name, selected.option as FieldPathValue<T, FieldPath<T>>);
+  }, [selected, name, setValue]);
 
   return (
-    <div>
-      {isLabel && (
-        <label
-          className="mb-[6px] block text-caption1 font-m text-sc-grays-1"
-          htmlFor={name}
-        >
-          {labelText}
-        </label>
-      )}
-      <input
-        {...register}
-        {...rest}
-        onFocus={() => setIsActive(true)}
-        // onBlur={() => setFocus(false)}
-        placeholder={placeholder}
-        id={name}
-        type="text"
-        className="w-full border-none appearance-none  focus:outline-none focus:ring-sc-org-1 focus:border-sc-org-1  placeholder:text-sc-grays-2 text-sc-black bg-sc-grays-6 rounded-[4px] px-2.5 py-0 h-8 text-footNote font-normal transition"
-      />
-      <div
-        className={cls(
-          'mt-2 divide-y-[1px] w-full rounded-lg shadow-md transition overflow-hidden',
-          isActive ? 'block' : 'hidden',
-        )}
-      >
-        {[...options].reverse().map((option, index) => (
-          <div
-            className="transition flex w-full items-center h-11 px-4 text-footNote text-sc-grays-1 hover:bg-sc-org-1 hover:text-sc-white"
-            key={index}
-            onClick={() => {
-              setIsActive(false);
-              setValue(name, option as FieldPathValue<T, FieldPath<T>>);
-            }}
-          >
-            {option}
+    <Listbox value={selected} onChange={setSelected}>
+      {({ open }) => (
+        <>
+          {isLabel && (
+            <Listbox.Label
+              htmlFor={name}
+              className="mb-[6px] block text-caption1 text-sc-grays-1"
+            >
+              {labelText}
+            </Listbox.Label>
+          )}
+          <div className="relative" id={name}>
+            <Listbox.Button
+              {...rest}
+              className="text-left text-sc-black w-full border-none appearance-none focus:outline-none focus:ring-sc-org-1 focus:border-sc-org-1  placeholder:text-sc-grays-2 bg-sc-grays-6 rounded px-2.5 py-0 h-8 text-footNote font-normal transition"
+            >
+              <span
+                className={cls(
+                  'flex items-center',
+                  selected.id !== 0 ? 'text-sc-black' : 'text-sc-grays-2',
+                )}
+              >
+                <span className="block truncate ">{selected.option}</span>
+              </span>
+              <span className="pointer-events-none absolute inset-y-0 right-0 ml-3 flex items-center pr-2">
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M16.5303 8.96967C16.8232 9.26256 16.8232 9.73744 16.5303 10.0303L12.5303 14.0303C12.2374 14.3232 11.7626 14.3232 11.4697 14.0303L7.46967 10.0303C7.17678 9.73744 7.17678 9.26256 7.46967 8.96967C7.76256 8.67678 8.23744 8.67678 8.53033 8.96967L12 12.4393L15.4697 8.96967C15.7626 8.67678 16.2374 8.67678 16.5303 8.96967Z"
+                    fill="#8E8E93"
+                  />
+                </svg>
+              </span>
+            </Listbox.Button>
+            <Transition
+              show={open}
+              as={Fragment}
+              leave="transition ease-in duration-100"
+              leaveFrom="opacity-100"
+              leaveTo="opacity-0"
+            >
+              <Listbox.Options className="shadow-lg divide-y-[1px] absolute text-footNote font-normal z-10 mt-2 w-full rounded bg-white overflow-hidden ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
+                {options?.map((option) => (
+                  <Listbox.Option
+                    key={option.id}
+                    className={({ active }) =>
+                      cls(
+                        active ? 'text-sc-white bg-sc-org-1' : 'text-gray-900',
+                        'flex items-center cursor-default select-none px-2.5 h-10 w-full',
+                      )
+                    }
+                    value={option}
+                  >
+                    {({ selected, active }) => (
+                      <>
+                        <div className="flex items-center">
+                          <span className="block truncate">
+                            {option.option}
+                          </span>
+                        </div>
+
+                        {selected ? (
+                          <span
+                            className={cls(
+                              active ? 'text-sc-white' : 'text-sc',
+                              'absolute inset-y-0 right-0 flex items-center pr-4',
+                            )}
+                          ></span>
+                        ) : null}
+                      </>
+                    )}
+                  </Listbox.Option>
+                ))}
+              </Listbox.Options>
+            </Transition>
           </div>
-        ))}
-      </div>
-    </div>
+        </>
+      )}
+    </Listbox>
   );
 }

--- a/src/pages/signup/signup02.tsx
+++ b/src/pages/signup/signup02.tsx
@@ -34,17 +34,16 @@ export default function Signup() {
           <Select
             name="admission_year"
             placeholder="입학년도를 선택해주세요."
-            register={register('admission_year')}
             setValue={setValue}
             options={[
-              '2015',
-              '2016',
-              '2017',
-              '2018',
-              '2019',
-              '2020',
-              '2021',
-              '2022',
+              { id: 1, option: '2015' },
+              { id: 2, option: '2016' },
+              { id: 3, option: '2017' },
+              { id: 4, option: '2018' },
+              { id: 5, option: '2019' },
+              { id: 6, option: '2020' },
+              { id: 7, option: '2021' },
+              { id: 8, option: '2022' },
             ]}
           />
         </div>

--- a/src/utils/cls.ts
+++ b/src/utils/cls.ts
@@ -1,3 +1,3 @@
 export default function cls(...className: string[]) {
-  return className.join(' ');
+  return className.filter(Boolean).join(' ');
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,13 @@
   dependencies:
     regenerator-runtime "^0.13.10"
 
+"@babel/runtime@^7.12.1":
+  version "7.20.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.1.tgz#1148bb33ab252b165a06698fde7576092a78b4a9"
+  integrity sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==
+  dependencies:
+    regenerator-runtime "^0.13.10"
+
 "@eslint/eslintrc@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.3.tgz#2b044ab39fdfa75b4688184f9e573ce3c5b0ff95"
@@ -31,6 +38,13 @@
     js-yaml "^4.1.0"
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
+
+"@headlessui/react@^1.7.4":
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.4.tgz#ba7f50fda20667276ee84fcd4c2a459aa26187e3"
+  integrity sha512-D8n5yGCF3WIkPsjEYeM8knn9jQ70bigGGb5aUvN6y4BGxcT3OcOQOKcM3zRGllRCZCFxCZyQvYJF6ZE7bQUOyQ==
+  dependencies:
+    client-only "^0.0.1"
 
 "@humanwhocodes/config-array@^0.11.6":
   version "0.11.6"
@@ -178,6 +192,14 @@
   dependencies:
     mini-svg-data-uri "^1.2.3"
 
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
@@ -223,6 +245,11 @@
   version "7.3.13"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
 "@typescript-eslint/eslint-plugin@^5.31.0":
   version "5.41.0"
@@ -560,7 +587,7 @@ chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-client-only@0.0.1:
+client-only@0.0.1, client-only@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
@@ -1230,6 +1257,13 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
@@ -1881,10 +1915,15 @@ react-hook-form@^7.38.0:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.38.0.tgz#53d6a68df587ce4ce88352f63e0ecc7fc8779320"
   integrity sha512-gxWW1kMeru9xR1GoR+Iw4hA+JBOM3SHfr4DWCUKY0xc7Vv1MLsF109oHtBeWl9shcyPFx67KHru44DheN0XY5A==
 
-react-is@^16.13.1:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^18.0.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
 react-query@^3.39.2:
   version "3.39.2"
@@ -1894,6 +1933,18 @@ react-query@^3.39.2:
     "@babel/runtime" "^7.5.5"
     broadcast-channel "^3.4.1"
     match-sorter "^6.0.2"
+
+react-redux@^8.0.5:
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-8.0.5.tgz#e5fb8331993a019b8aaf2e167a93d10af469c7bd"
+  integrity sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    "@types/use-sync-external-store" "^0.0.3"
+    hoist-non-react-statics "^3.3.2"
+    react-is "^18.0.0"
+    use-sync-external-store "^1.0.0"
 
 react@18.2.0:
   version "18.2.0"
@@ -1915,6 +1966,11 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
 
 redux-thunk@^2.4.1:
   version "2.4.1"
@@ -2244,7 +2300,7 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-use-sync-external-store@1.2.0:
+use-sync-external-store@1.2.0, use-sync-external-store@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==


### PR DESCRIPTION
- tailwind에서 완성된 ui를 사용하기 위해 headlessui/react라이브러리를 사용합니다.
- cls 유틸함수에 className들을 합치기 전에 배열을 한번 필터링하는 기능을 추가하였습니다.
- headlessui를 사용해서 select 컴포넌트를 새로 만들었습니다.
- select 함수에는 options 객체 배열이 props로 들어가고 react-hook-form에서는 setValue 함수만을 인자로 받습니다. 